### PR TITLE
Fix Doctrine project url

### DIFF
--- a/docs/book/architecture/architecture.rst
+++ b/docs/book/architecture/architecture.rst
@@ -34,7 +34,7 @@ Doctrine
 The most important are the object-relational mapper (ORM) and the database abstraction layer (DBAL).
 One of Doctrine's key features is the possibility to write database queries in Doctrine Query Language (DQL) - an object-oriented dialect of SQL.
 
-To learn more about Doctrine - see `their documentation <http://www.doctrine-project.org/about.html>`_.
+To learn more about Doctrine - see `their documentation <https://www.doctrine-project.org/>`_.
 
 Twig
 ----


### PR DESCRIPTION
Into "architecture overview", replace Doctrine "About" URL pointed to a "Page Not Found"

| Q               | A
| --------------- | -----
| Branch?         | 1.7, 1.8 or master <!-- see the comment below -->
| Bug fix?        | no/yes
| New feature?    | no/yes
| BC breaks?      | no/yes
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
